### PR TITLE
Updates API client to use actual API endpoints

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -70,26 +70,30 @@ func TestGetRoles(t *testing.T) {
 		{
 			name:           "successful get roles",
 			mockStatusCode: http.StatusOK,
-			mockResponse: `[
-				{
-					"v1": {
+			mockResponse: `{
+				"policies": [
+					{
+						"id": "test-admin-id",
+						"teamId": "test-team",
 						"name": "admin",
-						"resources": {
-							"allowed": ["**/*"],
-							"denied": ["kots/app/*/delete"]
-						}
-					}
-				},
-				{
-					"v1": {
+						"description": "Admin policy",
+						"definition": "{\"v1\":{\"name\":\"admin\",\"resources\":{\"allowed\":[\"**/*\"],\"denied\":[\"kots/app/*/delete\"]}}}",
+						"createdAt": "2023-01-01T00:00:00Z",
+						"modifiedAt": null,
+						"readOnly": false
+					},
+					{
+						"id": "test-viewer-id", 
+						"teamId": "test-team",
 						"name": "viewer",
-						"resources": {
-							"allowed": ["kots/app/*/read"],
-							"denied": []
-						}
+						"description": "Viewer policy",
+						"definition": "{\"v1\":{\"name\":\"viewer\",\"resources\":{\"allowed\":[\"kots/app/*/read\"],\"denied\":[]}}}",
+						"createdAt": "2023-01-01T00:00:00Z",
+						"modifiedAt": null,
+						"readOnly": false
 					}
-				}
-			]`,
+				]
+			}`,
 			expectedRoles: []models.Role{
 				{
 					Name: "admin",
@@ -110,7 +114,7 @@ func TestGetRoles(t *testing.T) {
 		{
 			name:           "empty roles list",
 			mockStatusCode: http.StatusOK,
-			mockResponse:   `[]`,
+			mockResponse:   `{"policies": []}`,
 			expectedRoles:  []models.Role{},
 		},
 		{
@@ -134,14 +138,14 @@ func TestGetRoles(t *testing.T) {
 				if r.Method != http.MethodGet {
 					t.Errorf("Expected GET request, got %s", r.Method)
 				}
-				if r.URL.Path != "/v1/team/policies" {
-					t.Errorf("Expected path /v1/team/policies, got %s", r.URL.Path)
+				if r.URL.Path != "/vendor/v3/policies" {
+					t.Errorf("Expected path /vendor/v3/policies, got %s", r.URL.Path)
 				}
 
 				// Verify authorization header
 				authHeader := r.Header.Get("Authorization")
-				if authHeader != "Bearer test-token" {
-					t.Errorf("Expected Authorization header 'Bearer test-token', got '%s'", authHeader)
+				if authHeader != "test-token" {
+					t.Errorf("Expected Authorization header 'test-token', got '%s'", authHeader)
 				}
 
 				w.WriteHeader(tt.mockStatusCode)
@@ -225,8 +229,8 @@ func TestCreateRole(t *testing.T) {
 				if r.Method != http.MethodPost {
 					t.Errorf("Expected POST request, got %s", r.Method)
 				}
-				if r.URL.Path != "/v1/team/policies" {
-					t.Errorf("Expected path /v1/team/policies, got %s", r.URL.Path)
+				if r.URL.Path != "/vendor/v3/policy" {
+					t.Errorf("Expected path /vendor/v3/policy, got %s", r.URL.Path)
 				}
 
 				// Verify content type
@@ -315,7 +319,7 @@ func TestUpdateRole(t *testing.T) {
 				if r.Method != http.MethodPut {
 					t.Errorf("Expected PUT request, got %s", r.Method)
 				}
-				expectedPath := "/v1/team/policies/" + role.Name
+				expectedPath := "/vendor/v3/policy/" + role.Name
 				if r.URL.Path != expectedPath {
 					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 				}
@@ -376,7 +380,7 @@ func TestDeleteRole(t *testing.T) {
 				if r.Method != http.MethodDelete {
 					t.Errorf("Expected DELETE request, got %s", r.Method)
 				}
-				expectedPath := "/v1/team/policies/" + tt.roleName
+				expectedPath := "/vendor/v3/policy/" + tt.roleName
 				if r.URL.Path != expectedPath {
 					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 				}
@@ -453,7 +457,7 @@ func TestGetRole(t *testing.T) {
 				if r.Method != http.MethodGet {
 					t.Errorf("Expected GET request, got %s", r.Method)
 				}
-				expectedPath := "/v1/team/policies/" + tt.roleName
+				expectedPath := "/vendor/v3/policy/" + tt.roleName
 				if r.URL.Path != expectedPath {
 					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
 				}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,7 +120,8 @@ confirm: true`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Clean up environment
+			// Clean up environment before and after test
+			cleanupEnv()
 			defer cleanupEnv()
 
 			// Set environment variables
@@ -276,7 +277,8 @@ func TestGetDefaultConfigPaths(t *testing.T) {
 }
 
 func TestLoadConfigWithDefaultPaths(t *testing.T) {
-	// Clean up environment
+	// Clean up environment before and after test
+	cleanupEnv()
 	defer cleanupEnv()
 	
 	// Create a temporary config file in a known location
@@ -309,7 +311,8 @@ log_level: debug`
 }
 
 func TestLoadConfigWithEnvironmentConfigPath(t *testing.T) {
-	// Clean up environment
+	// Clean up environment before and after test
+	cleanupEnv()
 	defer cleanupEnv()
 	
 	// Create a temporary config file
@@ -345,7 +348,8 @@ log_level: warn`
 }
 
 func TestLoadConfigEnvironmentOverridesConfigFile(t *testing.T) {
-	// Clean up environment
+	// Clean up environment before and after test
+	cleanupEnv()
 	defer cleanupEnv()
 	
 	// Create a temporary config file


### PR DESCRIPTION
TL;DR
-----

Corrects hallucinated V1 policy endpoints to vendor V3 endpoints

Details
--------

The existing API client was built around hallucinated V1 policy endpoints. This update migrates all API calls to the correct policy endpoints to ensure compatibility with the latest API version.

The change required several critical adjustments to accommodate the new API structure. All endpoint paths have been updated from `/v1/team/policies/*` to the new vendor format using `/vendor/v3/policy/*` for singular operations and `/vendor/v3/policies` for plural operations. The authorization mechanism has also changed—rather than prefixing tokens with "Bearer", the new endpoints require the raw token directly.

The most significant change involves response parsing, as the V3 API introduces a new policy response format that wraps results in a `policies` container and includes additional metadata. To handle this, we've added a new `Policy` model that represents the complete API response structure and implemented conversion logic to transform policy objects with embedded JSON definitions into our application's existing Role model.

All tests have been updated to verify proper endpoint paths and request/response handling, while the client interface remains unchanged so existing code won't require modification. Error handling has been improved to provide better context when policy conversion fails, and we've enhanced environment cleanup in config tests to prevent test interference by ensuring each test starts with a clean state.
