### PR TITLE
Enhances dry-run reporting with detailed diffs

### DIFF
--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -44,10 +44,12 @@ func CreateEnhancedSyncCommand(config models.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get flag values
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			dryRunDetailed, _ := cmd.Flags().GetBool("dry-run-detailed")
 			rolesDir, _ := cmd.Flags().GetString("roles-dir")
 			
 			// Use the unified sync command which now includes enhanced error handling
-			return RunSyncCommand(cmd, args, config, dryRun, rolesDir)
+			effectiveDryRun := dryRun || dryRunDetailed
+			return RunSyncCommand(cmd, args, config, effectiveDryRun, dryRunDetailed, rolesDir)
 		},
 	}
 	

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -44,12 +44,12 @@ func CreateEnhancedSyncCommand(config models.Config) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get flag values
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
-			dryRunDetailed, _ := cmd.Flags().GetBool("dry-run-detailed")
+			diff, _ := cmd.Flags().GetBool("diff")
 			rolesDir, _ := cmd.Flags().GetString("roles-dir")
 			
 			// Use the unified sync command which now includes enhanced error handling
-			effectiveDryRun := dryRun || dryRunDetailed
-			return RunSyncCommand(cmd, args, config, effectiveDryRun, dryRunDetailed, rolesDir)
+			effectiveDryRun := dryRun || diff
+			return RunSyncCommand(cmd, args, config, effectiveDryRun, diff, rolesDir)
 		},
 	}
 	

--- a/internal/cmd/logging_test.go
+++ b/internal/cmd/logging_test.go
@@ -169,7 +169,7 @@ func NewSyncCommandWithLogging(mockClient *MockClient, verbose bool) *cobra.Comm
 				Confirm:     false,
 				LogLevel:    "info",
 			}
-			return RunSyncCommandWithLogging(cmd, args, mockClient, dryRun, "", logger, config)
+			return RunSyncCommandWithLogging(cmd, args, mockClient, dryRun, false, "", logger, config)
 		},
 	}
 	

--- a/internal/cmd/roundtrip_test.go
+++ b/internal/cmd/roundtrip_test.go
@@ -461,7 +461,7 @@ func NewRoundTripSyncCommand(mockClient *MockClient) *cobra.Command {
 			
 			// Use the logging version which supports confirmation
 			logger := logging.NewLogger(cmd.OutOrStdout(), false)
-			return RunSyncCommandWithLogging(cmd, args, mockClient, dryRun, rolesDir, logger, config)
+			return RunSyncCommandWithLogging(cmd, args, mockClient, dryRun, false, rolesDir, logger, config)
 		},
 	}
 	

--- a/internal/cmd/sync_integration_test.go
+++ b/internal/cmd/sync_integration_test.go
@@ -403,7 +403,7 @@ func TestSyncCommandConfiguration(t *testing.T) {
 							APIEndpoint: "https://api.replicated.com",
 							APIToken:    "", // Empty token for this test
 						}
-						return RunSyncCommand(cmd, args, config, false, "")
+						return RunSyncCommand(cmd, args, config, false, false, "")
 					},
 				}
 			} else {

--- a/todo.md
+++ b/todo.md
@@ -59,7 +59,7 @@
 - [x] Test round-trip compatibility (using our mocks)
 
 #### Step 9: Advanced Features
-- [ ] Enhanced dry-run reporting with diffs
+- [x] Enhanced dry-run reporting with diffs
 - [ ] Comprehensive logging system
 - [ ] Performance optimizations
 - [ ] Production readiness improvements


### PR DESCRIPTION
TL;DR
-----

Adds --diff flag that provides comprehensive diff reporting showing exactly what changes would be made to role resources, including detailed before/after comparisons with +/- annotations for additions and removals.

Details
-------

Extends the existing dry-run functionality with enhanced reporting capabilities that show granular role permission changes. The new --diff flag generates human-readable diffs that clearly indicate which permissions will be added or removed from each role, providing users with precise visibility into the impact of their changes before execution.

The implementation adds a new ExecutePlanDryRunWithDiffs method that generates detailed information strings showing CREATE operations with full role definitions, UPDATE operations with +/- diff annotations for permission changes, and DELETE operations with role names. The DetailedSummary method provides enhanced output formatting that includes both the standard summary and the detailed diff information.

Integration with the sync command adds the new flag with proper help documentation and ensures that --diff implies --dry-run for user convenience. This completes the enhanced dry-run reporting requirement from Step 9 of the implementation plan, giving users the detailed change previews needed for confident role management.