### PR TITLE
Improves logging with proper stdout/stderr separation

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"replbac/internal/logging"
 	"replbac/internal/models"
 )
 
@@ -27,10 +28,11 @@ type Client struct {
 	baseURL    string
 	apiToken   string
 	httpClient *http.Client
+	logger     *logging.Logger
 }
 
 // NewClient creates a new API client with the given base URL and API token
-func NewClient(baseURL, apiToken string) (*Client, error) {
+func NewClient(baseURL, apiToken string, logger *logging.Logger) (*Client, error) {
 	// Validate base URL
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil || parsedURL.Scheme == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
@@ -42,21 +44,26 @@ func NewClient(baseURL, apiToken string) (*Client, error) {
 		return nil, fmt.Errorf("API token is required")
 	}
 
+	logger.Debug("creating API client for endpoint: %s", baseURL)
+	
 	return &Client{
 		baseURL:  strings.TrimSuffix(baseURL, "/"),
 		apiToken: apiToken,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		logger: logger,
 	}, nil
 }
 
 // getPolicies is a helper method to fetch raw policy data from the API
 func (c *Client) getPolicies() ([]models.Policy, error) {
 	url := c.baseURL + "/vendor/v3/policies"
+	c.logger.Debug("fetching policies from API endpoint: %s", url)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
+		c.logger.Error("failed to create HTTP request for %s: %v", url, err)
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -65,47 +72,60 @@ func (c *Client) getPolicies() ([]models.Policy, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		c.logger.Error("HTTP request failed for %s: %v", url, err)
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
+	c.logger.Debug("received HTTP response: status=%d", resp.StatusCode)
 	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("API request failed: GET %s returned status %d", url, resp.StatusCode)
 		return nil, c.handleErrorResponse(resp)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		c.logger.Error("failed to read response body from %s: %v", url, err)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	c.logger.Debug("received response body of %d bytes", len(body))
 	// Parse the response which has a "policies" wrapper
 	var response struct {
 		Policies []models.Policy `json:"policies"`
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
+		c.logger.Error("failed to parse JSON response from %s: %v", url, err)
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	c.logger.Info("successfully fetched %d policies from API", len(response.Policies))
 	return response.Policies, nil
 }
 
 // GetRoles retrieves all roles from the API
 func (c *Client) GetRoles() ([]models.Role, error) {
+	c.logger.Info("starting GetRoles operation")
 	policies, err := c.getPolicies()
 	if err != nil {
+		c.logger.Error("GetRoles failed during policy fetch: %v", err)
 		return nil, err
 	}
 
+	c.logger.Debug("converting %d policies to roles", len(policies))
 	// Convert policies to local roles
 	roles := make([]models.Role, 0, len(policies))
 	for _, policy := range policies {
+		c.logger.Debug("converting policy: %s", policy.Name)
 		role, err := policy.ToRole()
 		if err != nil {
+			c.logger.Error("failed to convert policy %s to role: %v", policy.Name, err)
 			return nil, fmt.Errorf("failed to convert policy %s: %w", policy.Name, err)
 		}
 		roles = append(roles, role)
 	}
 
+	c.logger.Info("successfully retrieved %d roles from API", len(roles))
 	return roles, nil
 }
 
@@ -128,12 +148,16 @@ func (c *Client) GetRole(roleName string) (models.Role, error) {
 
 // CreateRole creates a new role via the API
 func (c *Client) CreateRole(role models.Role) error {
+	c.logger.Info("creating role: %s", role.Name)
 	url := c.baseURL + "/vendor/v3/policy"
+	c.logger.Debug("creating role at endpoint: %s", url)
 
 	// Convert role to API format and create the policy structure
+	c.logger.Debug("converting role %s to API format", role.Name)
 	apiRole := role.ToAPIRole()
 	definitionJSON, err := json.Marshal(apiRole)
 	if err != nil {
+		c.logger.Error("failed to marshal role definition for %s: %v", role.Name, err)
 		return fmt.Errorf("failed to marshal role definition: %w", err)
 	}
 
@@ -163,24 +187,31 @@ func (c *Client) CreateRole(role models.Role) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		c.logger.Error("HTTP request failed for CreateRole %s: %v", role.Name, err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
+	c.logger.Debug("CreateRole response for %s: status=%d", role.Name, resp.StatusCode)
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		c.logger.Error("CreateRole failed for %s: status=%d", role.Name, resp.StatusCode)
 		return c.handleErrorResponse(resp)
 	}
 
+	c.logger.Info("successfully created role: %s", role.Name)
 	return nil
 }
 
 // UpdateRole updates an existing role via the API
 func (c *Client) UpdateRole(role models.Role) error {
+	c.logger.Info("updating role: %s (ID: %s)", role.Name, role.ID)
 	if role.ID == "" {
+		c.logger.Error("UpdateRole failed for %s: missing role ID", role.Name)
 		return fmt.Errorf("role ID is required for update operation")
 	}
 	
 	url := c.baseURL + "/vendor/v3/policy/" + role.ID
+	c.logger.Debug("updating role at endpoint: %s", url)
 
 	// Convert role to API format and create the policy update structure
 	apiRole := role.ToAPIRole()
@@ -215,22 +246,29 @@ func (c *Client) UpdateRole(role models.Role) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		c.logger.Error("HTTP request failed for UpdateRole %s: %v", role.Name, err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
+	c.logger.Debug("UpdateRole response for %s: status=%d", role.Name, resp.StatusCode)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		c.logger.Error("UpdateRole failed for %s: status=%d", role.Name, resp.StatusCode)
 		return c.handleErrorResponse(resp)
 	}
 
+	c.logger.Info("successfully updated role: %s", role.Name)
 	return nil
 }
 
 // DeleteRole deletes a role by name via the API
 func (c *Client) DeleteRole(roleName string) error {
+	c.logger.Info("deleting role: %s", roleName)
 	// Find the policy ID by name
+	c.logger.Debug("looking up policy ID for role: %s", roleName)
 	policies, err := c.getPolicies()
 	if err != nil {
+		c.logger.Error("DeleteRole failed for %s during policy lookup: %v", roleName, err)
 		return fmt.Errorf("failed to fetch policies: %w", err)
 	}
 	
@@ -243,10 +281,13 @@ func (c *Client) DeleteRole(roleName string) error {
 	}
 	
 	if policyID == "" {
+		c.logger.Warn("role not found for deletion: %s", roleName)
 		return fmt.Errorf("role not found: %s", roleName)
 	}
 	
+	c.logger.Debug("found policy ID %s for role %s", policyID, roleName)
 	url := c.baseURL + "/vendor/v3/policy/" + policyID
+	c.logger.Debug("deleting role at endpoint: %s", url)
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
@@ -258,14 +299,18 @@ func (c *Client) DeleteRole(roleName string) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		c.logger.Error("HTTP request failed for DeleteRole %s: %v", roleName, err)
 		return fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
+	c.logger.Debug("DeleteRole response for %s: status=%d", roleName, resp.StatusCode)
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		c.logger.Error("DeleteRole failed for %s: status=%d", roleName, resp.StatusCode)
 		return c.handleErrorResponse(resp)
 	}
 
+	c.logger.Info("successfully deleted role: %s", roleName)
 	return nil
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -99,13 +99,13 @@ func (c *Client) getPolicies() ([]models.Policy, error) {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	c.logger.Info("successfully fetched %d policies from API", len(response.Policies))
+	c.logger.Debug("successfully fetched %d policies from API", len(response.Policies))
 	return response.Policies, nil
 }
 
 // GetRoles retrieves all roles from the API
 func (c *Client) GetRoles() ([]models.Role, error) {
-	c.logger.Info("starting GetRoles operation")
+	c.logger.Debug("starting GetRoles operation")
 	policies, err := c.getPolicies()
 	if err != nil {
 		c.logger.Error("GetRoles failed during policy fetch: %v", err)
@@ -125,7 +125,7 @@ func (c *Client) GetRoles() ([]models.Role, error) {
 		roles = append(roles, role)
 	}
 
-	c.logger.Info("successfully retrieved %d roles from API", len(roles))
+	c.logger.Debug("successfully retrieved %d roles from API", len(roles))
 	return roles, nil
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,14 +1,22 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 
+	"replbac/internal/logging"
 	"replbac/internal/models"
 )
+
+// createTestLogger creates a logger for testing
+func createTestLogger() *logging.Logger {
+	var buf bytes.Buffer
+	return logging.NewLogger(&buf, true) // verbose for testing
+}
 
 func TestNewClient(t *testing.T) {
 	tests := []struct {
@@ -38,7 +46,7 @@ func TestNewClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client, err := NewClient(tt.baseURL, tt.apiToken)
+			client, err := NewClient(tt.baseURL, tt.apiToken, createTestLogger())
 
 			if tt.expectError {
 				if err == nil {
@@ -155,7 +163,7 @@ func TestGetRoles(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(server.URL, "test-token")
+			client, err := NewClient(server.URL, "test-token", createTestLogger())
 			if err != nil {
 				t.Fatalf("Failed to create client: %v", err)
 			}
@@ -272,7 +280,7 @@ func TestCreateRole(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(server.URL, "test-token")
+			client, err := NewClient(server.URL, "test-token", createTestLogger())
 			if err != nil {
 				t.Fatalf("Failed to create client: %v", err)
 			}
@@ -347,7 +355,7 @@ func TestUpdateRole(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(server.URL, "test-token")
+			client, err := NewClient(server.URL, "test-token", createTestLogger())
 			if err != nil {
 				t.Fatalf("Failed to create client: %v", err)
 			}
@@ -431,7 +439,7 @@ func TestDeleteRole(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(server.URL, "test-token")
+			client, err := NewClient(server.URL, "test-token", createTestLogger())
 			if err != nil {
 				t.Fatalf("Failed to create client: %v", err)
 			}
@@ -515,7 +523,7 @@ func TestGetRole(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := NewClient(server.URL, "test-token")
+			client, err := NewClient(server.URL, "test-token", createTestLogger())
 			if err != nil {
 				t.Fatalf("Failed to create client: %v", err)
 			}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -61,6 +61,10 @@ type InitResult struct {
 
 // RunInitCommand implements the main init logic with comprehensive error handling
 func RunInitCommand(cmd *cobra.Command, args []string, config models.Config, force bool, outputDir string) error {
+	// Ensure command output goes to stdout and logs go to stderr
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	
 	// Create logger that outputs to stderr
 	var logger *logging.Logger
 	if initDebug {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -78,8 +78,8 @@ func RunInitCommand(cmd *cobra.Command, args []string, config models.Config, for
 		targetDir = outputDir
 	}
 
-	logger.Info("starting init operation in directory: %s", targetDir)
 	cmd.Printf("Initializing role files in directory: %s\n", targetDir)
+	logger.Debug("starting init operation in directory: %s", targetDir)
 	
 	if force {
 		cmd.Println("FORCE: Existing files will be overwritten")

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -16,6 +16,8 @@ import (
 var (
 	initOutputDir string
 	initForce     bool
+	initVerbose   bool
+	initDebug     bool
 )
 
 // initCmd represents the init command
@@ -45,6 +47,8 @@ func init() {
 	// Init-specific flags
 	initCmd.Flags().StringVar(&initOutputDir, "output-dir", "", "directory to create role files (default: current directory)")
 	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing files")
+	initCmd.Flags().BoolVar(&initVerbose, "verbose", false, "enable info-level logging to stderr (progress and results)")
+	initCmd.Flags().BoolVar(&initDebug, "debug", false, "enable debug-level logging to stderr (detailed operation info)")
 }
 
 // InitResult contains the results of init operation
@@ -57,12 +61,13 @@ type InitResult struct {
 
 // RunInitCommand implements the main init logic with comprehensive error handling
 func RunInitCommand(cmd *cobra.Command, args []string, config models.Config, force bool, outputDir string) error {
-	// Create logger
-	verbose := false
-	if cmd.Flags().Lookup("verbose") != nil {
-		verbose, _ = cmd.Flags().GetBool("verbose")
+	// Create logger that outputs to stderr
+	var logger *logging.Logger
+	if initDebug {
+		logger = logging.NewDebugLogger(cmd.ErrOrStderr())
+	} else {
+		logger = logging.NewLogger(cmd.ErrOrStderr(), initVerbose)
 	}
-	logger := logging.NewLogger(cmd.OutOrStdout(), verbose)
 	
 	// Determine target directory
 	targetDir := "."

--- a/internal/cmd/logging_test.go
+++ b/internal/cmd/logging_test.go
@@ -28,16 +28,16 @@ func TestLoggingAndFeedback(t *testing.T) {
 			},
 			setupRemote:    []models.Role{},
 			dryRun:         false,
-			expectLogs:     []string{"[INFO]", "sync operation", "loaded 0 roles"},
-			expectProgress: []string{"processing roles from directory"},
+			expectLogs:     []string{"[DEBUG]", "sync operation", "loaded 0 roles"},
+			expectProgress: []string{"loading roles from directory"},
 		},
 		{
 			name:           "shows progress for empty directory",
 			setupRoles:     []models.Role{},
 			setupRemote:    []models.Role{},
 			dryRun:         false,
-			expectLogs:     []string{"[INFO]", "no roles found"},
-			expectProgress: []string{"processing roles from directory"},
+			expectLogs:     []string{"[DEBUG]", "no changes needed"},
+			expectProgress: []string{"loading roles from directory"},
 		},
 		{
 			name: "provides debug information in verbose mode",
@@ -46,7 +46,7 @@ func TestLoggingAndFeedback(t *testing.T) {
 			},
 			setupRemote: []models.Role{},
 			dryRun:      true,
-			expectLogs:  []string{"[INFO]", "sync operation"},
+			expectLogs:  []string{"[DEBUG]", "sync operation"},
 		},
 		{
 			name: "tracks operation timing",
@@ -55,8 +55,8 @@ func TestLoggingAndFeedback(t *testing.T) {
 			},
 			setupRemote:    []models.Role{},
 			dryRun:         false,
-			expectLogs:     []string{"[INFO]", "sync operation"},
-			expectProgress: []string{"processing roles from directory"},
+			expectLogs:     []string{"[DEBUG]", "sync operation"},
+			expectProgress: []string{"loading roles from directory"},
 		},
 	}
 

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -128,18 +128,15 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 		targetDir = rolesDir
 	}
 
-	logger.Info("sync operation starting")
-	logger.Debug("target directory: %s, dry-run: %v", targetDir, dryRun)
-	
 	cmd.Printf("Synchronizing roles from directory: %s\n", targetDir)
+	logger.Debug("sync operation starting: target directory: %s, dry-run: %v", targetDir, dryRun)
 	
 	if dryRun {
 		cmd.Println("DRY RUN: No changes will be applied")
 		logger.Debug("running in dry-run mode")
 	}
 
-	// Load local roles with progress feedback
-	logger.Info("processing roles from directory")
+	// Load local roles
 	logger.Debug("loading roles from directory: %s", targetDir)
 	
 	loadResult, err := roles.LoadRolesFromDirectoryWithDetails(targetDir)
@@ -156,7 +153,7 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 		return fmt.Errorf("failed to load local roles: %w", err)
 	}
 
-	logger.Info("loaded %d roles from directory", len(loadResult.Roles))
+	logger.Debug("loaded %d roles from directory", len(loadResult.Roles))
 	if len(loadResult.SkippedFiles) > 0 {
 		logger.Warn("skipped %d invalid files", len(loadResult.SkippedFiles))
 	}
@@ -175,7 +172,7 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 
 	// Get remote roles with progress feedback
 	if len(localRoles) > 0 {
-		logger.Info("synchronizing with remote API")
+		logger.Debug("synchronizing with remote API")
 	}
 	logger.Debug("fetching remote roles from API")
 
@@ -185,7 +182,7 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 		return HandleSyncError(cmd, fmt.Errorf("failed to get remote roles: %w", err))
 	}
 
-	logger.Info("fetched %d remote roles", len(remoteRoles))
+	logger.Debug("fetched %d remote roles", len(remoteRoles))
 	logger.Debug("comparing roles")
 
 	// Compare roles and generate sync plan
@@ -200,12 +197,12 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 	// Display plan summary
 	if !plan.HasChanges() {
 		cmd.Println("No changes needed")
-		logger.Info("no roles found" + " - no changes needed")
+		logger.Debug("no changes needed - plan has no changes")
 		return nil
 	}
 
 	cmd.Printf("Sync plan: %s\n", plan.Summary())
-	logger.Info("sync plan: %s", plan.Summary())
+	logger.Debug("sync plan: %s", plan.Summary())
 
 	// Display detailed plan
 	if len(plan.Creates) > 0 {
@@ -246,7 +243,7 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 		response = strings.ToLower(strings.TrimSpace(response))
 		if response != "y" && response != "yes" {
 			cmd.Println("Operation cancelled by user")
-			logger.Info("sync operation cancelled by user")
+			logger.Debug("sync operation cancelled by user")
 			return nil
 		}
 		logger.Debug("user confirmed deletion operation")
@@ -285,7 +282,7 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 	} else {
 		cmd.Printf("\nSync completed: %s\n", result.Summary())
 	}
-	logger.Info("sync operation completed successfully")
+	logger.Debug("sync operation completed successfully")
 
 	return nil
 }

--- a/internal/cmd/sync.go
+++ b/internal/cmd/sync.go
@@ -65,6 +65,10 @@ func init() {
 
 // RunSyncCommand implements the main sync logic with comprehensive error handling
 func RunSyncCommand(cmd *cobra.Command, args []string, config models.Config, dryRun bool, diff bool, rolesDir string) error {
+	// Ensure command output goes to stdout and logs go to stderr
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	
 	// Create logger that outputs to stderr
 	verbose := false
 	debug := false
@@ -289,6 +293,10 @@ func RunSyncCommandWithLogging(cmd *cobra.Command, args []string, client api.Cli
 
 // RunSyncCommandWithClient implements the main sync logic with dependency injection
 func RunSyncCommandWithClient(cmd *cobra.Command, args []string, client api.ClientInterface, dryRun bool, rolesDir string) error {
+	// Ensure command output goes to stdout and logs go to stderr
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	
 	// Create a logger that outputs to stderr
 	verbose := false
 	debug := false

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -23,17 +23,27 @@ type Logger struct {
 	verbose bool
 }
 
-// NewLogger creates a new logger instance
+// NewLogger creates a new logger instance that outputs to stderr by default
+// Default log level is ERROR for quiet operation
 func NewLogger(output io.Writer, verbose bool) *Logger {
-	level := InfoLevel
+	level := ErrorLevel // Default to ERROR level for quiet operation
 	if verbose {
-		level = DebugLevel
+		level = InfoLevel // --verbose enables INFO level
 	}
 	
 	return &Logger{
 		output:  output,
 		level:   level,
 		verbose: verbose,
+	}
+}
+
+// NewDebugLogger creates a logger with DEBUG level enabled
+func NewDebugLogger(output io.Writer) *Logger {
+	return &Logger{
+		output:  output,
+		level:   DebugLevel,
+		verbose: true,
 	}
 }
 
@@ -65,11 +75,6 @@ func (l *Logger) Error(msg string, args ...interface{}) {
 	}
 }
 
-// Progress logs progress messages for user feedback
-func (l *Logger) Progress(msg string, args ...interface{}) {
-	formattedMsg := fmt.Sprintf(msg, args...)
-	fmt.Fprintf(l.output, "%s\n", formattedMsg)
-}
 
 // TimedOperation tracks and logs the duration of an operation
 func (l *Logger) TimedOperation(operation string, fn func() error) error {

--- a/internal/sync/executor_test.go
+++ b/internal/sync/executor_test.go
@@ -1,11 +1,19 @@
 package sync
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
+	"replbac/internal/logging"
 	"replbac/internal/models"
 )
+
+// createTestLogger creates a logger for testing
+func createTestLogger() *logging.Logger {
+	var buf bytes.Buffer
+	return logging.NewLogger(&buf, true) // verbose for testing
+}
 
 // MockAPIClient implements the APIClient interface for testing
 type MockAPIClient struct {
@@ -369,7 +377,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 				tt.mockSetup(mockClient)
 			}
 
-			executor := NewExecutor(mockClient)
+			executor := NewExecutor(mockClient, createTestLogger())
 			result := executor.ExecutePlan(tt.plan)
 
 			// Check error expectations
@@ -476,7 +484,7 @@ func TestExecutor_ExecutePlanDryRun(t *testing.T) {
 	}
 
 	mockClient := &MockAPIClient{}
-	executor := NewExecutor(mockClient)
+	executor := NewExecutor(mockClient, createTestLogger())
 	
 	result := executor.ExecutePlanDryRun(plan)
 
@@ -511,7 +519,7 @@ func TestExecutor_ExecutePlanDryRun(t *testing.T) {
 
 func TestNewExecutor(t *testing.T) {
 	mockClient := &MockAPIClient{}
-	executor := NewExecutor(mockClient)
+	executor := NewExecutor(mockClient, createTestLogger())
 	
 	if executor == nil {
 		t.Error("NewExecutor() returned nil")
@@ -643,7 +651,7 @@ func TestExecutor_ExecutePlanDryRunWithDiffs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &MockAPIClient{}
-			executor := NewExecutor(mockClient)
+			executor := NewExecutor(mockClient, createTestLogger())
 			
 			result := executor.ExecutePlanDryRunWithDiffs(tt.plan)
 

--- a/internal/sync/scenarios_test.go
+++ b/internal/sync/scenarios_test.go
@@ -10,6 +10,7 @@ import (
 	"replbac/internal/roles"
 )
 
+
 // TestSyncScenarios tests various end-to-end sync scenarios
 func TestSyncScenarios(t *testing.T) {
 	tests := []struct {
@@ -305,7 +306,7 @@ func TestSyncScenarios(t *testing.T) {
 
 				// Test execution
 				mockClient := &MockAPIClient{}
-				executor := NewExecutor(mockClient)
+				executor := NewExecutor(mockClient, createTestLogger())
 				result := executor.ExecutePlan(plan)
 
 				// Verify execution result
@@ -618,7 +619,7 @@ func TestSyncErrorScenarios(t *testing.T) {
 			}
 
 			// Execute sync
-			executor := NewExecutor(mockClient)
+			executor := NewExecutor(mockClient, createTestLogger())
 			result := executor.ExecutePlan(plan)
 
 			// Verify error expectations

--- a/policies/Admin.yaml
+++ b/policies/Admin.yaml
@@ -1,0 +1,9 @@
+# WARNING: The 'id' field is managed by the Replicated API and should not be modified manually.
+# Changing the ID will cause sync operations to fail.
+
+id: sBQUfKnvbhEZEUBevHf1ovi3qx20BfZ6
+name: Admin
+resources:
+    allowed:
+        - '**/*'
+    denied: []

--- a/policies/Read Only.yaml
+++ b/policies/Read Only.yaml
@@ -1,0 +1,11 @@
+# WARNING: The 'id' field is managed by the Replicated API and should not be modified manually.
+# Changing the ID will cause sync operations to fail.
+
+id: dFNafGuOkbYxJ3REO2ryIK6ymb788zim
+name: Read Only
+resources:
+    allowed:
+        - '**/list'
+        - '**/read'
+    denied:
+        - '**/*'

--- a/policies/Sales.yaml
+++ b/policies/Sales.yaml
@@ -1,0 +1,18 @@
+# WARNING: The 'id' field is managed by the Replicated API and should not be modified manually.
+# Changing the ID will cause sync operations to fail.
+
+id: 434b7749813b141cc381a4fcc59362a9
+name: Sales
+resources:
+    allowed:
+        - platform/app/*/read
+        - platform/app/*/channel/*/read
+        - platform/app/*/licensefields/read
+        - platform/app/*/license/**
+        - kots/app/*/read
+        - kots/app/*/channel/*/read
+        - kots/app/*/licensefields/read
+        - kots/app/*/license/**
+        - kots/license/**
+    denied:
+        - '**/*'

--- a/policies/Slackernews and CMX Sales Demo.yaml
+++ b/policies/Slackernews and CMX Sales Demo.yaml
@@ -1,0 +1,21 @@
+# WARNING: The 'id' field is managed by the Replicated API and should not be modified manually.
+# Changing the ID will cause sync operations to fail.
+
+id: uGIHQTXXZj4IzJ64WQxmg3gnzifmjY2y
+name: Slackernews and CMX Sales Demo
+resources:
+    allowed:
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/license/**
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/channel/*/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/channel/*/releases/**
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/licensefields/*/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/license/*/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/license/*/slack-notifications/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/release/*/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/supportbundle/read
+        - kots/app/2Ukd6bgLamUYOegqsNOPfjpfQVC/customhostname/list
+        - kots/cluster/**
+        - kots/vm/**
+        - kots/license/**
+    denied: []

--- a/policies/Support Engineer.yaml
+++ b/policies/Support Engineer.yaml
@@ -1,0 +1,15 @@
+# WARNING: The 'id' field is managed by the Replicated API and should not be modified manually.
+# Changing the ID will cause sync operations to fail.
+
+id: d0064564510f0d6555941094a0712e82
+name: Support Engineer
+resources:
+    allowed:
+        - '**/read'
+        - '**/list'
+        - platform/app/*/license/**
+        - kots/app/*/license/**
+        - team/support-issues/triage
+        - team/support-issues/write
+    denied:
+        - '**/*'

--- a/todo.md
+++ b/todo.md
@@ -60,7 +60,7 @@
 
 #### Step 9: Advanced Features
 - [x] Enhanced dry-run reporting with diffs
-- [ ] Comprehensive logging system
+- [x] Comprehensive logging system
 - [ ] Performance optimizations
 - [ ] Production readiness improvements
 


### PR DESCRIPTION
TL;DR
-----

Transforms logging from mixed output streams to proper CLI behavior with user messages on stdout and technical logging on stderr, enabling clean shell redirection and automation workflows.

Details
-------

Refactors the logging architecture to follow standard Unix CLI conventions by implementing proper stream separation throughout the application. User-facing status messages like operation progress, results, and completion notifications now flow through stdout via cmd.Printf, while technical logging including debug information, API call details, and error diagnostics route through stderr via the logger infrastructure.

The implementation addresses a fundamental usability issue where all output was inadvertently mixed on stderr, breaking standard shell redirection patterns that users expect from professional CLI tools. With the corrected behavior, commands like `replbac init > results.txt` now capture clean user output, `replbac init 2> debug.log` isolates technical logging, and `replbac init >/dev/null` runs silently for automation scenarios.

Beyond stream correction, the changes eliminate duplicate messaging between user-facing output and technical logging, reducing noise while maintaining comprehensive troubleshooting capabilities. The logging levels have been refined so that default operation produces minimal output, --verbose enables progress visibility, and --debug provides detailed technical diagnostics, giving users precise control over the information they receive.