### PR TITLE
Refines release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,13 @@ jobs:
         GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p bin
-        go build -o bin/replbac-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+        COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        go build \
+          -ldflags "-X replbac/internal/cmd.Version=${VERSION} -X replbac/internal/cmd.GitCommit=${COMMIT} -X replbac/internal/cmd.BuildDate=${BUILD_DATE}" \
+          -o bin/replbac-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }} \
+          ./cmd/replbac
 
     - name: Test binary
       if: matrix.os == 'linux' && matrix.arch == 'amd64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,13 +126,13 @@ jobs:
         GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p dist
-        go build -o bin/$${{ matrix.os }}/${{ matrix.arch }}/replbac ${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        go build -o dist/$${{ matrix.os }}/${{ matrix.arch }}/replbac ${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
 
     - name: Test binary
       if: matrix.os == 'linux' && matrix.arch == 'amd64'
       run: |
-        chmod +x bin/linux/amd64/replbac
-        ./bin/linux/amd64/replbac version
+        chmod +x dist/linux/amd64/replbac
+        ./dist/linux/amd64/replbac version
 
     - name: Create archives
       run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,12 +79,10 @@ jobs:
       with:
         args: './...'
 
-  release:
-    name: release
+  build:
+    name: build
     runs-on: ubuntu-latest
     needs: security
-    outputs:
-      digests: ${{ steps.hash.outputs.digests }}
     strategy:
       matrix:
         os: [linux, darwin, windows]
@@ -160,12 +158,40 @@ jobs:
         rm -rf "${bin_dir}"
         cd "${workspace}"
 
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: replbac-${{ matrix.os }}-${{ matrix.arch }}
+        path: dist/*
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      digests: ${{ steps.hash.outputs.digests }}
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+
+    - name: Organize release files
+      run: |
+        mkdir -p dist
+        find artifacts -name "*.tar.gz" -o -name "*.zip" | xargs -I {} cp {} dist/
+        ls -la dist/
+
     - name: Generate checksums and digests
       id: hash
       run: |
         cd dist
         # Only checksum files, not directories
-        sha256sum *.tar.gz *.zip 2>/dev/null | tee checksums.txt || echo "No archives found for this platform"
+        sha256sum *.tar.gz *.zip 2>/dev/null | tee checksums.txt || echo "No archives found"
         
         # Generate SLSA digests (only for files that exist)
         if [ -s checksums.txt ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,15 +137,16 @@ jobs:
 
     - name: Create archives
       run: |
-        bin_dir=dist/linux/amd64
+        dist_dir=dist
+        bin_dir=${dist_dir}/${os}/${arch}
         workspace="$(pwd)"
         output_name=replbac-v0.0.1-linux-amd64
 
         cd "${bin_dir}" 
         if [[ ! "$os" == "windows" ]]; then 
-          tar -czf "dist/${output_name}.tar.gz" replbac 
+          tar -czf "${dist_dir}/${output_name}.tar.gz" replbac 
         else 
-          zip "${output_name%.exe}.zip" replbac.exe 
+          zip "${dist_dir}/${output_name%.exe}.zip" replbac.exe 
         fi
 
         rm -rf "${bin_dir}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,21 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Release
+  test:
+    name: Test
     runs-on: ubuntu-latest
-    outputs:
-      digests: ${{ steps.hash.outputs.digests }}
+    strategy:
+      matrix:
+        go-version: ['1.23', '1.24']
     
     steps:
     - name: Check out code
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: ${{ matrix.go-version }}
 
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -37,45 +36,119 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
-    - name: Run tests
-      run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+    - name: Verify dependencies
+      run: go mod verify
 
-    - name: Build binaries
+    - name: Check formatting
+      run: |
+        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+          echo "Code is not formatted properly:"
+          gofmt -s -l .
+          exit 1
+        fi
+
+    - name: Run go vet
+      run: go vet ./...
+
+    - name: Install golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
+
+    - name: Run golangci-lint
+      run: $(go env GOPATH)/bin/golangci-lint run
+
+    - name: Run tests
+      run: go test -race ./...
+
+  security:
+    name: Security Scan
+    needs: test
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Run Gosec Security Scanner
+      uses: securego/gosec@v2.22.4
+      with:
+        args: './...'
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    needs: security
+    outputs:
+      digests: ${{ steps.hash.outputs.digests }}
+    strategy:
+      matrix:
+        os: [linux, darwin, windows]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows
+            arch: arm64
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Extract version number
+      id: version
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        version=${tag#v}
+        echo "version=$version" >> $GITHUB_OUTPUT
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Build binary
+      env:
+        GOOS: ${{ matrix.os }}
+        GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p dist
-        
-        # Build for multiple platforms
-        platforms=(
-          "linux/amd64"
-          "linux/arm64"
-          "darwin/amd64"
-          "darwin/arm64"
-          "windows/amd64"
-        )
-        
-        for platform in "${platforms[@]}"; do
-          os=$(echo $platform | cut -d'/' -f1)
-          arch=$(echo $platform | cut -d'/' -f2)
-          output_name="replbac-${os}-${arch}"
-          
-          if [ "$os" = "windows" ]; then
-            output_name="${output_name}.exe"
-          fi
-          
-          echo "Building for $os/$arch..."
-          GOOS=$os GOARCH=$arch go build -ldflags="-s -w -X main.version=${GITHUB_REF#refs/tags/}" -o "dist/${output_name}" ./cmd/replbac
-          
-          # Create archive for non-Windows platforms
+        go build -o bin/$${{ matrix.os }}/${{ matrix.arch }}/replbac ${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+
+    - name: Test binary
+      if: matrix.os == 'linux' && matrix.arch == 'amd64'
+      run: |
+        chmod +x bin/linux/amd64/replbac
+        ./bin/linux/amd64/replbac version
+
+    - name: Create archives
+      run:
+          workspace=$(pwd)
+          output_name=replbac-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
           if [ "$os" != "windows" ]; then
-            cd dist
+            cd dist/${os}/${arch}
             tar -czf "${output_name}.tar.gz" "${output_name}"
-            rm "${output_name}"
-            cd ..
+            rm replbac
+            cd ${workspace} 
           else
             cd dist
+            tar -czf "${output_name}.tar.gz" "${output_name}"
             zip "${output_name%.exe}.zip" "${output_name}"
-            rm "${output_name}"
-            cd ..
+            rm replbac.exe
+            cd ${workspace} 
           fi
         done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p dist
-        go build -o dist/$${{ matrix.os }}/${{ matrix.arch }}/replbac ${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        go build -o dist/$${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
 
     - name: Test binary
       if: matrix.os == 'linux' && matrix.arch == 'amd64'
@@ -136,21 +136,20 @@ jobs:
 
     - name: Create archives
       run:
+          bin_dir=dist/${{ matrix.os }}/${{ matrix.arch }}
           workspace=$(pwd)
           output_name=replbac-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
           if [ "$os" != "windows" ]; then
-            cd dist/${os}/${arch}
-            tar -czf "${output_name}.tar.gz" "${output_name}"
-            rm replbac
+            cd ${bin_dir}
+            tar -czf "dist/${output_name}.tar.gz" replbac
+            rm -rf ${bin_dir}
             cd ${workspace} 
           else
-            cd dist
-            tar -czf "${output_name}.tar.gz" "${output_name}"
-            zip "${output_name%.exe}.zip" "${output_name}"
-            rm replbac.exe
+            cd ${bin_dir}
+            zip "${output_name%.exe}.zip" replbac.exe
+            rm -rf ${bin_dir}
             cd ${workspace} 
           fi
-        done
 
     - name: Generate checksums and digests
       id: hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         ./dist/linux/amd64/replbac version
 
     - name: Create archives
-      run:
+      run: |
         bin_dir=dist/linux/amd64
         workspace="$(pwd)"
         output_name=replbac-v0.0.1-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,10 +164,15 @@ jobs:
       id: hash
       run: |
         cd dist
-        sha256sum * > checksums.txt
+        # Only checksum files, not directories
+        sha256sum *.tar.gz *.zip 2>/dev/null | tee checksums.txt || echo "No archives found for this platform"
         
-        # Generate SLSA digests
-        echo "digests=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+        # Generate SLSA digests (only for files that exist)
+        if [ -s checksums.txt ]; then
+          echo "digests=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+        else
+          echo "digests=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,16 +137,16 @@ jobs:
 
     - name: Create archives
       run: |
-        dist_dir=dist
-        bin_dir=${dist_dir}/${os}/${arch}
         workspace="$(pwd)"
-        output_name=replbac-v0.0.1-linux-amd64
+        dist_dir="${workspace}/dist"
+        bin_dir=${dist_dir}/${os}/${arch}
+        base_name=replbac-${{ step.version.output.version }}-${os}-${arch}
 
         cd "${bin_dir}" 
         if [[ ! "$os" == "windows" ]]; then 
-          tar -czf "${dist_dir}/${output_name}.tar.gz" replbac 
+          tar -czf "${dist_dir}/${base_name}.tar.gz" replbac 
         else 
-          zip "${dist_dir}/${output_name%.exe}.zip" replbac.exe 
+          zip "${dist_dir}/${base_name}.zip" replbac.exe 
         fi
 
         rm -rf "${bin_dir}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         workspace="$(pwd)"
         dist_dir="${workspace}/dist"
         bin_dir=${dist_dir}/${os}/${arch}
-        base_name=replbac-${{ step.version.output.version }}-${os}-${arch}
+        base_name=replbac-${{ steps.version.output.version }}-${os}-${arch}
 
         cd "${bin_dir}" 
         if [[ ! "$os" == "windows" ]]; then 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
           workspace=$(pwd)
           output_name=replbac-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
 
-          if [[ "$os" != "windows" ]]; then
+          if [[ ! "$os" == "windows" ]]; then
             cd ${bin_dir}
             tar -czf "dist/${output_name}.tar.gz" replbac
             rm -rf ${bin_dir}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.release.outputs.digests }}"
       upload-assets: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
         cd "${workspace}"
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: replbac-${{ matrix.os }}-${{ matrix.arch }}
         path: dist/*
@@ -176,7 +176,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download all artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,8 @@ jobs:
           bin_dir=dist/${{ matrix.os }}/${{ matrix.arch }}
           workspace=$(pwd)
           output_name=replbac-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
-          if [ "$os" != "windows" ]; then
+
+          if [[ "$os" != "windows" ]]; then
             cd ${bin_dir}
             tar -czf "dist/${output_name}.tar.gz" replbac
             rm -rf ${bin_dir}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,6 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
         arch: [amd64, arm64]
-        exclude:
-          - os: windows
-            arch: arm64
 
     steps:
     - name: Check out code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,13 @@ jobs:
         GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p dist
-        go build -o dist/${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        VERSION=${{ steps.version.outputs.version }}
+        COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        go build \
+          -ldflags "-X replbac/internal/cmd.Version=${VERSION} -X replbac/internal/cmd.GitCommit=${COMMIT} -X replbac/internal/cmd.BuildDate=${BUILD_DATE}" \
+          -o dist/${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} \
+          ./cmd/replbac
         ls dist/${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} 
 
     - name: Test binary
@@ -139,11 +145,13 @@ jobs:
       run: |
         workspace="$(pwd)"
         dist_dir="${workspace}/dist"
-        bin_dir=${dist_dir}/${os}/${arch}
-        base_name=replbac-${{ steps.version.output.version }}-${os}-${arch}
+        os="${{ matrix.os }}"
+        arch="${{ matrix.arch }}"
+        bin_dir="${dist_dir}/${os}/${arch}"
+        base_name="replbac-${{ steps.version.outputs.version }}-${os}-${arch}"
 
         cd "${bin_dir}" 
-        if [[ ! "$os" == "windows" ]]; then 
+        if [[ ! "${os}" == "windows" ]]; then 
           tar -czf "${dist_dir}/${base_name}.tar.gz" replbac 
         else 
           zip "${dist_dir}/${base_name}.zip" replbac.exe 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-${{ matrix.go-version }}
 
     - name: Download dependencies
       run: go mod download
@@ -113,9 +113,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-go-${{ matrix.go-version }}
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,8 @@ jobs:
         GOARCH: ${{ matrix.arch }}
       run: |
         mkdir -p dist
-        go build -o dist/$${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        go build -o dist/${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} ./cmd/replbac
+        ls dist/${{ matrix.os }}/${{ matrix.arch }}/replbac${{ matrix.os == 'windows' && '.exe' || '' }} 
 
     - name: Test binary
       if: matrix.os == 'linux' && matrix.arch == 'amd64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,21 +137,19 @@ jobs:
 
     - name: Create archives
       run:
-          bin_dir=dist/${{ matrix.os }}/${{ matrix.arch }}
-          workspace=$(pwd)
-          output_name=replbac-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
+        bin_dir=dist/linux/amd64
+        workspace="$(pwd)"
+        output_name=replbac-v0.0.1-linux-amd64
 
-          if [[ ! "$os" == "windows" ]]; then
-            cd ${bin_dir}
-            tar -czf "dist/${output_name}.tar.gz" replbac
-            rm -rf ${bin_dir}
-            cd ${workspace} 
-          else
-            cd ${bin_dir}
-            zip "${output_name%.exe}.zip" replbac.exe
-            rm -rf ${bin_dir}
-            cd ${workspace} 
-          fi
+        cd "${bin_dir}" 
+        if [[ ! "$os" == "windows" ]]; then 
+          tar -czf "dist/${output_name}.tar.gz" replbac 
+        else 
+          zip "${output_name%.exe}.zip" replbac.exe 
+        fi
+
+        rm -rf "${bin_dir}"
+        cd "${workspace}"
 
     - name: Generate checksums and digests
       id: hash


### PR DESCRIPTION
TL;DR
-----

Overhauls the release workflow and embeds version metadata directly into build
artifacts

Details
--------

The current build process produces binaries that lack embedded version
information, leaving users unable to identify which version they're running.
This change solves that problem by injecting version details, git commit
hashes, and build timestamps directly into binaries through linker flags
during compilation.

Restructures the release workflow. Testing now spans appropriate Go versions
to ensure broad compatibility, while a dedicated security scanning step using
Gosec catches potential vulnerabilities before release. The build matrix
systematically covers all platform combinations, and artifact naming has been
standardized for consistency across releases. Release assets are now better
organized, making downloads more intuitive for users.

Finally, updates to the latest SLSA framework version.
